### PR TITLE
Add support for escaping all request variables

### DIFF
--- a/escape_json.c
+++ b/escape_json.c
@@ -1,42 +1,36 @@
 /*
   uWSGI plugin that creates custom json-escaped logging variables.
-  
+
   build plugin with `uwsgi --build-plugin <filename.c>`
   and use it with `uwsgi --plugin <filename_plugin.so> ...`
 */
 #include <uwsgi.h>
 
+// Inspired by
+// https://github.com/unbit/uwsgi/blob/52d858af7148a7084628d1241a7597441bb84f95/core/logging.c#L1986-L2031
+#define lf_json(x, y) \
+  static ssize_t uwsgi_lf_json_ ## x(struct wsgi_request *wsgi_req, char **buf) { \
+    long pos = offsetof(struct wsgi_request, y); \
+    long pos_len = offsetof(struct wsgi_request, y ## _len); \
+    char **var = (char **) (((char *) wsgi_req) + pos); \
+    uint16_t *varlen = (uint16_t *) (((char *) wsgi_req) + pos_len); \
+    *buf = uwsgi_malloc((*varlen * 2) + 1); \
+    escape_json(*var, *varlen, *buf); \
+    return strlen(*buf); \
+  }
 
-static ssize_t uwsgi_lf_json_uri(struct wsgi_request *wsgi_req, char **buf) {
-    long pos = offsetof(struct wsgi_request, uri);
-    long pos_len = offsetof(struct wsgi_request, uri_len);
-    char **var = (char **) (((char *) wsgi_req) + pos);
-    uint16_t *varlen = (uint16_t *) (((char *) wsgi_req) + pos_len);
+#define r_logchunk(x) \
+  uwsgi_register_logchunk("json_" #x, uwsgi_lf_json_ ## x, 1)
 
-    char *e_json = uwsgi_malloc((*varlen * 2) + 1);
-    escape_json(*var, *varlen, e_json);
-    *buf = e_json;
-    return strlen(*buf);
-}
-
-static ssize_t uwsgi_lf_json_host(struct wsgi_request *wsgi_req, char **buf) {
-    long pos = offsetof(struct wsgi_request, host);
-    long pos_len = offsetof(struct wsgi_request, host_len);
-    char **var = (char **) (((char *) wsgi_req) + pos);
-    uint16_t *varlen = (uint16_t *) (((char *) wsgi_req) + pos_len);
-
-    char *e_json = uwsgi_malloc((*varlen * 2) + 1);
-    escape_json(*var, *varlen, e_json);
-    *buf = e_json;
-    return strlen(*buf);
-}
+lf_json(uri, uri)
+lf_json(host, host)
 
 static void register_logchunks() {
-        uwsgi_register_logchunk("json_uri", uwsgi_lf_json_uri, 1);
-        uwsgi_register_logchunk("json_host", uwsgi_lf_json_host, 1);
+  r_logchunk(uri);
+  r_logchunk(host);
 }
 
 struct uwsgi_plugin escape_json_plugin = {
-        .name = "escape_json",
-        .on_load = register_logchunks,
+  .name = "escape_json",
+  .on_load = register_logchunks,
 };

--- a/escape_json.c
+++ b/escape_json.c
@@ -23,11 +23,23 @@
   uwsgi_register_logchunk("json_" #x, uwsgi_lf_json_ ## x, 1)
 
 lf_json(uri, uri)
+lf_json(method, method)
+lf_json(user, remote_user)
+lf_json(addr, remote_addr)
 lf_json(host, host)
+lf_json(proto, protocol)
+lf_json(uagent, user_agent)
+lf_json(referer, referer)
 
 static void register_logchunks() {
   r_logchunk(uri);
+  r_logchunk(method);
+  r_logchunk(user);
+  r_logchunk(addr);
   r_logchunk(host);
+  r_logchunk(proto);
+  r_logchunk(uagent);
+  r_logchunk(referer);
 }
 
 struct uwsgi_plugin escape_json_plugin = {


### PR DESCRIPTION
Hi 👋 .

First of all, thanks for this plugin. It saved me quite a bit of research time 👍 

The proposed changes are relatively simple. I introduced a couple of macros to reduce the boilerplate and defined _logchunks_ for all remaining request variables. I think the latter is quite useful since pretty much all of the request variables can be set to arbitrary values by clients, e.g. `curl -X 'F"OO' ...`.